### PR TITLE
Added 'undefined' element check

### DIFF
--- a/src/components/yearcollapse.jsx
+++ b/src/components/yearcollapse.jsx
@@ -32,6 +32,10 @@ class YearCollapse extends Component {
         for (let index = 0; index < 20; index++) {
             const element = this.state.year.value[index];
 
+            if (typeof element == 'undefined') {
+                continue;
+            }
+            
             var box = <div className="box reason" key={element.key}>
                 <h3>{element.value.name}</h3>
                 <h5>{element.value.artist}</h5>


### PR DESCRIPTION
If an element is undefined when calculating the top songs, it will now ignore the undefined element and just continue to the next one. This prevents a blank page that shows no results.